### PR TITLE
Patch: add autopatches SQL migration file for custom dateCreated & dateModified column in some tables

### DIFF
--- a/resources/sql/autopatches/20221117.datefields.01.project.sql
+++ b/resources/sql/autopatches/20221117.datefields.01.project.sql
@@ -4,14 +4,6 @@ ALTER TABLE {$NAMESPACE}_project.project_columnposition
 ALTER TABLE {$NAMESPACE}_project.project_columnposition
   ADD column dateModified INT(10) UNSIGNED;
 
-CREATE TRIGGER before_phabricator_project_project_columnposition_insert
-  BEFORE INSERT ON phabricator_project.project_columnposition
-    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
-
-CREATE TRIGGER before_phabricator_project_project_columnposition_update
-  BEFORE UPDATE ON phabricator_project.project_columnposition
-    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
-
 UPDATE {$NAMESPACE}_project.project_columnposition
   SET dateCreated = UNIX_TIMESTAMP();
 

--- a/resources/sql/autopatches/20221117.datefields.01.project.sql
+++ b/resources/sql/autopatches/20221117.datefields.01.project.sql
@@ -5,11 +5,11 @@ ALTER TABLE {$NAMESPACE}_project.project_columnposition
   ADD column dateModified INT(10) UNSIGNED;
 
 CREATE TRIGGER before_phabricator_project_project_columnposition_insert
-  BEFORE INSERT ON {$NAMESPACE}_project.project_columnposition
+  BEFORE INSERT ON phabricator_project.project_columnposition
     FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
 
 CREATE TRIGGER before_phabricator_project_project_columnposition_update
-  BEFORE UPDATE ON {$NAMESPACE}_project.project_columnposition
+  BEFORE UPDATE ON phabricator_project.project_columnposition
     FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
 
 UPDATE {$NAMESPACE}_project.project_columnposition

--- a/resources/sql/autopatches/20221117.datefields.01.project.sql
+++ b/resources/sql/autopatches/20221117.datefields.01.project.sql
@@ -1,0 +1,19 @@
+ALTER TABLE {$NAMESPACE}_project.project_columnposition
+  ADD column dateCreated INT(10) UNSIGNED;
+
+ALTER TABLE {$NAMESPACE}_project.project_columnposition
+  ADD column dateModified INT(10) UNSIGNED;
+
+CREATE TRIGGER before_phabricator_project_project_columnposition_insert
+  BEFORE INSERT ON {$NAMESPACE}_project.project_columnposition
+    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
+
+CREATE TRIGGER before_phabricator_project_project_columnposition_update
+  BEFORE UPDATE ON {$NAMESPACE}_project.project_columnposition
+    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_project.project_columnposition
+  SET dateCreated = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_project.project_columnposition
+  SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
+++ b/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
@@ -2,11 +2,11 @@ ALTER TABLE {$NAMESPACE}_maniphest.edge
   ADD column dateModified INT(10) UNSIGNED;
 
 CREATE TRIGGER before_phabricator_maniphest_edge_insert
-  BEFORE INSERT ON {$NAMESPACE}_maniphest.edge
+  BEFORE INSERT ON phabricator_maniphest.edge
     FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
 
 CREATE TRIGGER before_phabricator_maniphest_edge_update
-  BEFORE UPDATE ON {$NAMESPACE}_maniphest.edge
+  BEFORE UPDATE ON phabricator_maniphest.edge
     FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
 
 UPDATE {$NAMESPACE}_maniphest.edge

--- a/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
+++ b/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
@@ -1,0 +1,13 @@
+ALTER TABLE {$NAMESPACE}_maniphest.edge
+  ADD column dateModified INT(10) UNSIGNED;
+
+CREATE TRIGGER before_phabricator_maniphest_edge_insert
+  BEFORE INSERT ON {$NAMESPACE}_maniphest.edge
+    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
+
+CREATE TRIGGER before_phabricator_maniphest_edge_update
+  BEFORE UPDATE ON {$NAMESPACE}_maniphest.edge
+    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_maniphest.edge
+  SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
+++ b/resources/sql/autopatches/20221117.datefields.02.maniphest.sql
@@ -1,13 +1,5 @@
 ALTER TABLE {$NAMESPACE}_maniphest.edge
   ADD column dateModified INT(10) UNSIGNED;
 
-CREATE TRIGGER before_phabricator_maniphest_edge_insert
-  BEFORE INSERT ON phabricator_maniphest.edge
-    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
-
-CREATE TRIGGER before_phabricator_maniphest_edge_update
-  BEFORE UPDATE ON phabricator_maniphest.edge
-    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
-
 UPDATE {$NAMESPACE}_maniphest.edge
   SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20221117.datefields.03.differential.sql
+++ b/resources/sql/autopatches/20221117.datefields.03.differential.sql
@@ -2,11 +2,11 @@ ALTER TABLE {$NAMESPACE}_differential.edge
   ADD column dateModified INT(10) UNSIGNED;
 
 CREATE TRIGGER before_phabricator_differential_edge_insert
-  BEFORE INSERT ON {$NAMESPACE}_differential.edge
+  BEFORE INSERT ON phabricator_differential.edge
     FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
 
 CREATE TRIGGER before_phabricator_differential_edge_update
-  BEFORE UPDATE ON {$NAMESPACE}_differential.edge
+  BEFORE UPDATE ON phabricator_differential.edge
     FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
 
 UPDATE {$NAMESPACE}_differential.edge

--- a/resources/sql/autopatches/20221117.datefields.03.differential.sql
+++ b/resources/sql/autopatches/20221117.datefields.03.differential.sql
@@ -1,0 +1,13 @@
+ALTER TABLE {$NAMESPACE}_differential.edge
+  ADD column dateModified INT(10) UNSIGNED;
+
+CREATE TRIGGER before_phabricator_differential_edge_insert
+  BEFORE INSERT ON {$NAMESPACE}_differential.edge
+    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
+
+CREATE TRIGGER before_phabricator_differential_edge_update
+  BEFORE UPDATE ON {$NAMESPACE}_differential.edge
+    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_differential.edge
+  SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20221117.datefields.03.differential.sql
+++ b/resources/sql/autopatches/20221117.datefields.03.differential.sql
@@ -1,13 +1,5 @@
 ALTER TABLE {$NAMESPACE}_differential.edge
   ADD column dateModified INT(10) UNSIGNED;
 
-CREATE TRIGGER before_phabricator_differential_edge_insert
-  BEFORE INSERT ON phabricator_differential.edge
-    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
-
-CREATE TRIGGER before_phabricator_differential_edge_update
-  BEFORE UPDATE ON phabricator_differential.edge
-    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
-
 UPDATE {$NAMESPACE}_differential.edge
   SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20240503.datefields.01.task.sql
+++ b/resources/sql/autopatches/20240503.datefields.01.task.sql
@@ -4,14 +4,6 @@ ALTER TABLE {$NAMESPACE}_maniphest.maniphest_task_ffield
 ALTER TABLE {$NAMESPACE}_maniphest.maniphest_task_ffield
   ADD column dateModified INT(10) UNSIGNED;
 
-CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_insert
-  BEFORE INSERT ON phabricator_maniphest.maniphest_task_ffield
-    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
-
-CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_update
-  BEFORE UPDATE ON phabricator_maniphest.maniphest_task_ffield
-    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
-
 UPDATE {$NAMESPACE}_maniphest.maniphest_task_ffield
   SET dateCreated = UNIX_TIMESTAMP();
 

--- a/resources/sql/autopatches/20240503.datefields.01.task.sql
+++ b/resources/sql/autopatches/20240503.datefields.01.task.sql
@@ -1,0 +1,19 @@
+ALTER TABLE {$NAMESPACE}_maniphest.maniphest_task_ffield
+  ADD column dateCreated INT(10) UNSIGNED;
+
+ALTER TABLE {$NAMESPACE}_maniphest.maniphest_task_ffield
+  ADD column dateModified INT(10) UNSIGNED;
+
+CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_insert
+  BEFORE INSERT ON {$NAMESPACE}_maniphest.maniphest_task_ffield
+    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
+
+CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_update
+  BEFORE UPDATE ON {$NAMESPACE}_maniphest.maniphest_task_ffield
+    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_maniphest.maniphest_task_ffield
+  SET dateCreated = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_maniphest.maniphest_task_ffield
+  SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20240503.datefields.01.task.sql
+++ b/resources/sql/autopatches/20240503.datefields.01.task.sql
@@ -5,11 +5,11 @@ ALTER TABLE {$NAMESPACE}_maniphest.maniphest_task_ffield
   ADD column dateModified INT(10) UNSIGNED;
 
 CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_insert
-  BEFORE INSERT ON {$NAMESPACE}_maniphest.maniphest_task_ffield
+  BEFORE INSERT ON phabricator_maniphest.maniphest_task_ffield
     FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
 
 CREATE TRIGGER before_phabricator_maniphest_maniphest_task_ffield_update
-  BEFORE UPDATE ON {$NAMESPACE}_maniphest.maniphest_task_ffield
+  BEFORE UPDATE ON phabricator_maniphest.maniphest_task_ffield
     FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
 
 UPDATE {$NAMESPACE}_maniphest.maniphest_task_ffield

--- a/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
+++ b/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
@@ -4,14 +4,6 @@ ALTER TABLE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
 ALTER TABLE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
   ADD column dateModified INT(10) UNSIGNED;
 
-CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_insert
-  BEFORE INSERT ON phabricator_maniphest.maniphest_customfieldstorage
-    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
-
-CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_update
-  BEFORE UPDATE ON phabricator_maniphest.maniphest_customfieldstorage
-    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
-
 UPDATE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
   SET dateCreated = UNIX_TIMESTAMP();
 

--- a/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
+++ b/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
@@ -1,0 +1,19 @@
+ALTER TABLE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  ADD column dateCreated INT(10) UNSIGNED;
+
+ALTER TABLE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  ADD column dateModified INT(10) UNSIGNED;
+
+CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_insert
+  BEFORE INSERT ON {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+    FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
+
+CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_update
+  BEFORE UPDATE ON {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+    FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  SET dateCreated = UNIX_TIMESTAMP();
+
+UPDATE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  SET dateModified = UNIX_TIMESTAMP();

--- a/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
+++ b/resources/sql/autopatches/20240503.datefields.02.customfieldstorage.sql
@@ -5,11 +5,11 @@ ALTER TABLE {$NAMESPACE}_maniphest.maniphest_customfieldstorage
   ADD column dateModified INT(10) UNSIGNED;
 
 CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_insert
-  BEFORE INSERT ON {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  BEFORE INSERT ON phabricator_maniphest.maniphest_customfieldstorage
     FOR EACH ROW SET NEW.dateCreated = UNIX_TIMESTAMP(), NEW.dateModified = UNIX_TIMESTAMP();
 
 CREATE TRIGGER before_phabricator_maniphest_maniphest_customfieldstorage_update
-  BEFORE UPDATE ON {$NAMESPACE}_maniphest.maniphest_customfieldstorage
+  BEFORE UPDATE ON phabricator_maniphest.maniphest_customfieldstorage
     FOR EACH ROW SET NEW.dateModified = UNIX_TIMESTAMP();
 
 UPDATE {$NAMESPACE}_maniphest.maniphest_customfieldstorage


### PR DESCRIPTION
In recent years, we add columns to some tables in phabricator that will be used by Data Team in redash. The schema upgrade is done manually by running SQL script directly. It is not proper that since that migration we keep getting error warning after `bin/storage upgrade`
```
SURPLUS SCHEMATA
You have surplus schemata (extra tables or columns which this software does not expect). For information on resolving these issues, see the "Surplus Schemata" section in the "Managing Storage Adjustments" article in the documentation.
```
The errors also shown in Phabricator Web UI
![image](https://github.com/user-attachments/assets/37239613-40a0-4272-9a79-d4574d43e17a)

This PR should fix surplus schemata error warning.

Reference:
https://p.cermati.com/T73228
https://p.cermati.com/T102212
